### PR TITLE
alter output location and create directory for output location

### DIFF
--- a/src/main/java/com/rackspace/salus/salus_tools/converter/SwaggerJsonConverter.java
+++ b/src/main/java/com/rackspace/salus/salus_tools/converter/SwaggerJsonConverter.java
@@ -67,7 +67,9 @@ public class SwaggerJsonConverter {
             pathNode.set(key, node);
         });
         root.set("paths", pathNode);
-        mapper.writeValue(new java.io.File(args[0]+"/convertedOutput.json"), (JsonNode)root);
+        // if this fails to create the directory then the public documentation wont get generated
+        new java.io.File(args[0]+"/public/").mkdir();
+        mapper.writeValue(new java.io.File(args[0] + "/public/swagger.json"), (JsonNode) root);
 
     }
 }

--- a/src/main/java/com/rackspace/salus/salus_tools/converter/SwaggerJsonConverter.java
+++ b/src/main/java/com/rackspace/salus/salus_tools/converter/SwaggerJsonConverter.java
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -68,8 +71,8 @@ public class SwaggerJsonConverter {
         });
         root.set("paths", pathNode);
         // if this fails to create the directory then the public documentation wont get generated
-        new java.io.File(args[0]+"/public/").mkdir();
-        mapper.writeValue(new java.io.File(args[0] + "/public/swagger.json"), (JsonNode) root);
+        Path parent= Files.createDirectory(Paths.get(args[0] +"/public/"));
+        mapper.writeValue(parent.resolve("swagger.json").toFile(), (JsonNode) root);
 
     }
 }


### PR DESCRIPTION
# Resolves

SALUS-355

# What

Make sure that the public directory exists before outputting the swagger.json there

# How

Creates the folder and outputs the new swagger to that directory with the new name swagger.json

## How to test

compile then run install


# Why

I couldn't see a way from the maven plugin to alter the filename target of what it was generating from so this was a nice compromise that also delineated what API was being generated for

# TODO

None
