### PR TITLE
Fix the GCB build directory of data-loader

### DIFF
--- a/data-loader/cloudbuild.yaml
+++ b/data-loader/cloudbuild.yaml
@@ -1,12 +1,14 @@
 steps:
   - name: 'mirror.gcr.io/library/golang'
     env: ['GO111MODULE=on']
+    dir: data-loader
     args:
       - go
       - test
       - ./...
   # using Docker build caching https://cloud.google.com/cloud-build/docs/kaniko-cache
   - name: 'gcr.io/kaniko-project/executor:latest'
+    dir: data-loader
     args:
       - --destination=gcr.io/$PROJECT_ID/data-loader
       - --cache=true


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-698

# What

Build in GCB was failing with

```
Step #0: go: warning: "./..." matched no packages
Step #0: no packages to test
Finished Step #0
ERROR
ERROR: build step 0 "mirror.gcr.io/library/golang" failed: exit status 1
```

# How

Build's workspace is the top of the repo, so need to explicitly declare the subdir. I was able to mimic the real build and test the change with

```
cloud-build-local --config data-loader/cloudbuild.yaml --dryrun=false .
```

## How to test

Using `cloud-build-local`