### PR TITLE
kaniko needs context specified rather than using step's dir

### DIFF
--- a/data-loader/cloudbuild.yaml
+++ b/data-loader/cloudbuild.yaml
@@ -8,7 +8,7 @@ steps:
       - ./...
   # using Docker build caching https://cloud.google.com/cloud-build/docs/kaniko-cache
   - name: 'gcr.io/kaniko-project/executor:latest'
-    dir: data-loader
     args:
+      - --context=/workspace/data-loader
       - --destination=gcr.io/$PROJECT_ID/data-loader
       - --cache=true


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-698

# What

Build was reporting the error

```
Step #1: error building image: error building stage: lstat /workspace/go.sum: no such file or directory
Finished Step #1
ERROR
ERROR: build step 1 "gcr.io/kaniko-project/executor:latest" failed: exit status 1
```

# How

Since the kaniko context wasn't honoring the step's `dir` setting, setting its context explicitly ([reference](https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts))

## How to test

Let the local cloud build actually run to that step:
```
cloud-build-local --config data-loader/cloudbuild.yaml --dryrun=false .
```