### PR TITLE
Refactor Identity auth over to go-restclient

### DIFF
--- a/data-loader/go.mod
+++ b/data-loader/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-github/v28 v28.1.1
 	github.com/google/subcommands v1.0.1
 	github.com/itzg/go-flagsfiller v1.4.0
-	github.com/racker/go-restclient v1.1.0
+	github.com/racker/go-restclient v1.2.0
 	github.com/stretchr/testify v1.4.0
 	github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0
 	go.uber.org/multierr v1.4.0 // indirect

--- a/data-loader/go.sum
+++ b/data-loader/go.sum
@@ -51,6 +51,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/racker/go-restclient v1.1.0 h1:S4lwpzyciyx9AsVPs1hlYrtk8l5cFteEd3+BDkbLgZk=
 github.com/racker/go-restclient v1.1.0/go.mod h1:JgqybDO4w0eCtddnRsIW+UGGHeG1wgfZof7ZOs+tPHQ=
+github.com/racker/go-restclient v1.2.0 h1:GfZTPHFiAiVoREw/MxKPAPtrtnEUq0lYfMlQLQVnsuY=
+github.com/racker/go-restclient v1.2.0/go.mod h1:JgqybDO4w0eCtddnRsIW+UGGHeG1wgfZof7ZOs+tPHQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/data-loader/loaders.go
+++ b/data-loader/loaders.go
@@ -92,7 +92,7 @@ func NewLoader(log *zap.SugaredLogger, identityAuthenticator restclient.Intercep
 	ourLogger.Debugw("Setting up loader",
 		"adminUrl", adminUrl)
 
-	restClient := restclient.New()
+	restClient := restclient.NewClient()
 	err := restClient.SetBaseUrl(adminUrl)
 	if err != nil {
 		return nil, fmt.Errorf("invalid admin URL: %w", err)

--- a/data-loader/loaders.go
+++ b/data-loader/loaders.go
@@ -87,7 +87,7 @@ func setupAndLoad(config *Config, log *zap.SugaredLogger, sourceContent SourceCo
 	return nil
 }
 
-func NewLoader(log *zap.SugaredLogger, identityAuthenticator *IdentityAuthenticator, adminUrl string) (Loader, error) {
+func NewLoader(log *zap.SugaredLogger, identityAuthenticator restclient.Interceptor, adminUrl string) (Loader, error) {
 	ourLogger := log.Named("loader")
 	ourLogger.Debugw("Setting up loader",
 		"adminUrl", adminUrl)
@@ -99,7 +99,7 @@ func NewLoader(log *zap.SugaredLogger, identityAuthenticator *IdentityAuthentica
 	}
 	restClient.Timeout = getterTimeout
 	if identityAuthenticator != nil {
-		restClient.AddInterceptor(identityAuthenticator.Intercept)
+		restClient.AddInterceptor(identityAuthenticator)
 	}
 
 	return &LoaderImpl{


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-732

# What

The data-loader was its own Identity authentication interceptor contained within the main package. That didn't allow for reuse in other projects.

# How

Use the IdentityV2Authenticator refactored in https://github.com/racker/go-restclient/pull/3

## How to test

Ran against the dev cluster but with `load-from-local /tmp/empty` subcommand pointing at an empty content area.

# TODO

Will update `go.mod` when https://github.com/racker/go-restclient/pull/3 is merged and new release tagged
