### PR TITLE
Upgraded go-restclient so that REST errors actually reveal the cause

### DIFF
--- a/data-loader/go.mod
+++ b/data-loader/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-github/v28 v28.1.1
 	github.com/google/subcommands v1.0.1
 	github.com/itzg/go-flagsfiller v1.4.0
-	github.com/racker/go-restclient v1.2.0
+	github.com/racker/go-restclient v1.2.1
 	github.com/stretchr/testify v1.4.0
 	github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0
 	go.uber.org/multierr v1.4.0 // indirect

--- a/data-loader/go.sum
+++ b/data-loader/go.sum
@@ -53,6 +53,8 @@ github.com/racker/go-restclient v1.1.0 h1:S4lwpzyciyx9AsVPs1hlYrtk8l5cFteEd3+BDk
 github.com/racker/go-restclient v1.1.0/go.mod h1:JgqybDO4w0eCtddnRsIW+UGGHeG1wgfZof7ZOs+tPHQ=
 github.com/racker/go-restclient v1.2.0 h1:GfZTPHFiAiVoREw/MxKPAPtrtnEUq0lYfMlQLQVnsuY=
 github.com/racker/go-restclient v1.2.0/go.mod h1:JgqybDO4w0eCtddnRsIW+UGGHeG1wgfZof7ZOs+tPHQ=
+github.com/racker/go-restclient v1.2.1 h1:2G/T0cRKHltgndWPH3yl4S/kOq2tQ5kXf89I6I9Hl7s=
+github.com/racker/go-restclient v1.2.1/go.mod h1:JgqybDO4w0eCtddnRsIW+UGGHeG1wgfZof7ZOs+tPHQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/data-loader/loader_definitions.go
+++ b/data-loader/loader_definitions.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ var loaderDefinitions = []LoaderDefinition{
 		Name:    "monitor-translations",
 		ApiPath: "/api/monitor-translations",
 		UniqueFieldPaths: []string{
+			"$.monitorType",
 			"$.name",
 		},
 	},


### PR DESCRIPTION
# What

When hitting constraint violations while running data-loader the issue was not apparent just looking at the error including in the data-loader logs, such as

```
body=[{\"timestamp\":\"2020-01-15T21:34:34.024+0000\",\"status\":503,\"error\":\"Service Unavailable\",\"message\":\"Th]
```

# How

Upgrade go-restclient to pickup https://github.com/racker/go-restclient/pull/4

# Test

Truncate monitor translations table and re-run data-loader as of [this point in data-loader-content](https://github.com/Rackspace-Segment-Support/salus-data-loader-content/tree/d53318b673153e40a4d777f1f182d11eaa9207ba)