### PR TITLE
Add policy loader definitions

### DIFF
--- a/data-loader/loader_definitions.go
+++ b/data-loader/loader_definitions.go
@@ -35,4 +35,22 @@ var loaderDefinitions = []LoaderDefinition{
 			"$.name",
 		},
 	},
+	{
+		Name:    "policy-monitors",
+		ApiPath: "/api/policy-monitors",
+		UniqueFieldPaths: []string{
+			"$.name",
+		},
+	},
+	{
+		Name:    "monitor-metadata-policies",
+		ApiPath: "/api/policy/metadata/monitor",
+		UniqueFieldPaths: []string{
+			"$.scope",
+			"$.subscope",
+			"$.targetClassName",
+			"$.valueType",
+			"$.key",
+		},
+	},
 }


### PR DESCRIPTION
# What

Adds definitions for handling [data loader content](https://github.com/Rackspace-Segment-Support/salus-data-loader-content) for both monitor metadata policies and policy monitors.

# How

The unique fields for the metadata match those that must be unique in the database.

Only the `name` is unique for the monitors.  In reality monitors do not have easily determined fields that can be used to class them as "unique" but as these will only be used in dev (see the TODO) this is the easiest way here.

## How to test

I've ran it manually.

# Why

We want to populate as much as we can into our environments so it is immediately usable.  Policy metadata is currently the most important as the api will fail if you try to create a monitor with no interval if there is not a policy for that field... but including monitors also helps to make "dev" environments more like prod for demoing or even just working through new features.

# TODO

_Policy Monitors_ are the monitors that get used in a _Monitor Policy_.  Due to this dependency _Monitor Policies_ cannot yet be added to data loader.  The payload to create one requires including a `monitorId` of a policy monitor.

There is an open jira to look into the solution for this.

-----

A separate repo should be created for data loader content that is specific to dev environments.

For example, we likely will not want to create policy monitors in prod through the data loader.  It is something that should happen manually only when needed (almost never after the first time).  To prevent that content from accidentally being included in prod we will have a separate repo whose webhook is only connected to the data loader in dev (and potentially stage).

----
Add content for the metadata policies.