### PR TITLE
Added logic to ensure UniqueFieldPaths is not empty

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
 # Resolves
 
-    <Jira or Github issue reference(s)>
+<Jira or Github issue reference(s)>
 
 # What
 
-    <What is this PR is trying to accomplish?>
+<What is this PR is trying to accomplish?>
 
 # How
 
-    <How is the PR designed to solve the problem?>
+<How is the PR designed to solve the problem?>
 
-## How to test
+# How to test
 
-    <instructions for verifying the changes specific to this PR>
+<instructions for verifying the changes specific to this PR>
 
 # Why
 
-    <Why was the final approach taken? Were alternatives considered?>
+<Why was the final approach taken? Were alternatives considered?>
 
 # TODO
 
-    <outstanding tasks before this PR is considered 'ready'>
+<outstanding tasks before this PR is considered 'ready'>

--- a/data-loader/loaders.go
+++ b/data-loader/loaders.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -216,6 +216,13 @@ func (UniquenessTracker) formKey(fieldValues []interface{}) string {
 }
 
 func (l *LoaderImpl) identifyExistingContent(definition LoaderDefinition, allContent []interface{}) (UniquenessTracker, error) {
+	// if UniqueFieldPaths is empty then the uniqueness key always becomes an empty string,
+	// in which case, content will load only if a GET for existing content returns nothing. After
+	// that point all existing content via GET will look like it has the same empty-string-key as
+	// the content to be loaded and nothing will get loaded.
+	if len(definition.UniqueFieldPaths) == 0 {
+		return nil, fmt.Errorf("UniqueFieldPaths cannot be empty for %+v", definition)
+	}
 	tracker := make(UniquenessTracker)
 
 	for _, v := range allContent {

--- a/data-loader/loaders_test.go
+++ b/data-loader/loaders_test.go
@@ -133,6 +133,39 @@ func TestLoaderImpl_LoadAll(t *testing.T) {
 	assert.Equal(t, 0, stats.FailedToCreate)
 }
 
+func TestLoaderDefinitions_validUniqueFieldPaths(t *testing.T) {
+	for _, definition := range loaderDefinitions {
+		assert.NotEmpty(t, definition.UniqueFieldPaths,
+			"%s must have non-empty unique field paths", definition.Name)
+	}
+}
+
+func TestLoaderImpl_identifyExistingContent_emptyUniqueFieldPaths(t *testing.T) {
+	loader := &LoaderImpl{}
+	content := make([]interface{}, 0)
+	_, err := loader.identifyExistingContent(LoaderDefinition{
+		Name:             "testing",
+		ApiPath:          "/api/testing",
+		UniqueFieldPaths: []string{},
+	}, content)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "UniqueFieldPaths cannot be empty")
+}
+
+func TestLoaderImpl_identifyExistingContent_nilUniqueFieldPaths(t *testing.T) {
+	loader := &LoaderImpl{}
+	content := make([]interface{}, 0)
+	_, err := loader.identifyExistingContent(LoaderDefinition{
+		Name:             "testing",
+		ApiPath:          "/api/testing",
+		UniqueFieldPaths: nil,
+	}, content)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "UniqueFieldPaths cannot be empty")
+}
+
 func assertJsonPath(t *testing.T, postedJson interface{}, path string, expected interface{}) {
 	field, err := jsonpath.Read(postedJson, path)
 	require.NoError(t, err)


### PR DESCRIPTION
# What

It wasn't obvious that the `UniqueFieldPaths` is required in the `loaderDefintions`.
 
# How

At runtime, a definition's "section" will be stopped and the error logged if the paths are empty.

At unit test time, the `loaderDefinitions` are validated.

So, hopefully between those two we'll catch misconfigs during builds and worst case at runtime.

## How to test

Added relevant unit tests