### PR TITLE
Added data-loader support for zones

### DIFF
--- a/data-loader/loader_definitions.go
+++ b/data-loader/loader_definitions.go
@@ -35,4 +35,11 @@ var loaderDefinitions = []LoaderDefinition{
 			"$.name",
 		},
 	},
+	{
+		Name:    "zones",
+		ApiPath: "/api/zones",
+		UniqueFieldPaths: []string{
+			"$.name",
+		},
+	},
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-734

# What

Public zones are currently manually loaded into each cluster.

# How

Add `zones` as a support data-loader type and admin api endpoint.

# How to test

Ran locally with the content in https://github.com/Rackspace-Segment-Support/salus-data-loader-content/pull/9