### PR TITLE
Added specific response when event's ref is ignored

### DIFF
--- a/data-loader/webhook.go
+++ b/data-loader/webhook.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,13 +93,24 @@ func (s *WebhookServer) handleWebhook(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		statsJson, err := json.Marshal(stats)
-		if err != nil {
-			s.log.Warnw("failed marshal stats response",
-				"err", err, "stats", stats)
+		if stats != nil {
+			statsJson, err := json.Marshal(stats)
+			if err != nil {
+				s.log.Warnw("failed marshal stats response",
+					"err", err, "stats", stats)
+			} else {
+				w.Header().Set("Content-Type", string(restclient.JsonType))
+				_, err = w.Write(statsJson)
+				if err != nil {
+					s.log.Warnw("failed to send stats json response", "err", err)
+				}
+			}
 		} else {
-			w.Header().Set("Content-Type", string(restclient.JsonType))
-			_, _ = w.Write(statsJson)
+			w.Header().Set("Content-Type", string(restclient.TextType))
+			_, err = w.Write([]byte("event ref ignored by configuration"))
+			if err != nil {
+				s.log.Warnw("failed to send ref ignored response", "err", err)
+			}
 		}
 
 	default:

--- a/data-loader/webhook.go
+++ b/data-loader/webhook.go
@@ -107,7 +107,7 @@ func (s *WebhookServer) handleWebhook(w http.ResponseWriter, r *http.Request) {
 			}
 		} else {
 			w.Header().Set("Content-Type", string(restclient.TextType))
-			_, err = w.Write([]byte("event ref ignored by configuration"))
+			_, err = w.Write([]byte("Ignoring github webhook request for unconfigured branch/tag"))
 			if err != nil {
 				s.log.Warnw("failed to send ref ignored response", "err", err)
 			}

--- a/data-loader/webhook_test.go
+++ b/data-loader/webhook_test.go
@@ -254,7 +254,7 @@ func TestWebhookServer_handleWebhook_MisMatchRef(t *testing.T) {
 	assert.Equal(t, 200, result.StatusCode)
 	bodyBytes, err := ioutil.ReadAll(result.Body)
 	require.NoError(t, err)
-	assert.Equal(t, "event ref ignored by configuration", string(bodyBytes))
+	assert.Equal(t, "Ignoring github webhook request for unconfigured branch/tag", string(bodyBytes))
 	assert.Equal(t, "text/plain", result.Header.Get("Content-Type"))
 
 	loader.AssertExpectations(t)

--- a/data-loader/webhook_test.go
+++ b/data-loader/webhook_test.go
@@ -255,6 +255,7 @@ func TestWebhookServer_handleWebhook_MisMatchRef(t *testing.T) {
 	bodyBytes, err := ioutil.ReadAll(result.Body)
 	require.NoError(t, err)
 	assert.Equal(t, "event ref ignored by configuration", string(bodyBytes))
+	assert.Equal(t, "text/plain", result.Header.Get("Content-Type"))
 
 	loader.AssertExpectations(t)
 	builder.AssertExpectations(t)


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-773

# What

When data-loader processed a webhook is was configured to ignore, it responded with the negative sounding body "null".

# How

Set content type to text and respond with a human meaningful response body.

# How to test

Updated existing test