### PR TITLE
e2et: Adjusted private zone ID to conform to lowercase constraint

### DIFF
--- a/e2et/main.go
+++ b/e2et/main.go
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package main
@@ -28,7 +26,6 @@ import (
 	"fmt"
 	"github.com/coreos/go-semver/semver"
 	"github.com/satori/go.uuid"
-	"github.com/segmentio/kafka-go"
 	"github.com/shirou/gopsutil/process"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -55,7 +52,7 @@ func initConfig() config {
 	c.mode = viper.GetString("mode")
 	c.currentUUID = uuid.NewV4()
 	c.id = strings.Replace(c.currentUUID.String(), "-", "", -1)
-	c.privateZoneId = "privateZone_" + c.id
+	c.privateZoneId = "private_zone_" + c.id
 	c.resourceId = "resource-id-" + c.id
 	c.tenantId = viper.GetString("tenant.id")
 	c.publicApiUrl = viper.GetString("public.api.url")


### PR DESCRIPTION
# What

End to End test run was reporting this error:
```
Only lowercase alphanumeric and underscore characters can be used","objectName":"zoneCreatePrivate","field":"name","rejectedValue":"privateZone_7a7a146a75d641b8a7ca4b03654b8e2c
```

# How

Adjusted private zone ID generation to conform to constraint update in https://github.com/racker/salus-telemetry-monitor-management/pull/150

cc @nicksunday 