### PR TITLE
Add tenant metadata definitions

### DIFF
--- a/data-loader/loader_definitions.go
+++ b/data-loader/loader_definitions.go
@@ -60,4 +60,11 @@ var loaderDefinitions = []LoaderDefinition{
 			"$.key",
 		},
 	},
+	{
+		Name:    "tenant-metadata",
+		ApiPath: "/api/tenant-metadata",
+		UniqueFieldPaths: []string{
+			"$.tenantId",
+		},
+	},
 }


### PR DESCRIPTION
New definition to create things like:

```
{
  "tenantId": "aaaaaa",
  "metadata": {
    "description": "random account for local dev testing"
  }
} 
```