### PR TITLE
fix e2et for policy management changes

### DIFF
--- a/e2et/main.go
+++ b/e2et/main.go
@@ -517,7 +517,6 @@ func deletePolicyMonitors(c config) {
 		pageStr := fmt.Sprintf("?page=%d", page)
 		body := doReq("GET", policyUrl+pageStr,
 			"", "getting all policy monitors", c.adminToken)
-		log.Println("gbj delete policy monitor: " + string(body))
 		var resp GetPoliciesResp
 		err := json.Unmarshal(body, &resp)
 		checkErr(err, "unable to parse get policy monitors response")
@@ -527,7 +526,7 @@ func deletePolicyMonitors(c config) {
 				continue
 			}
 
-			// opt out of policy
+			// opt out of policy to remove cloned monitor
 			data := fmt.Sprintf(tenantPolicyData, c.tenantId, i.ID)
 			body = doReq("POST", policyUrl, data, "creating opt out policy", c.adminToken)
 			var resp GetPolicyResp

--- a/e2et/templates.go
+++ b/e2et/templates.go
@@ -123,9 +123,16 @@ const httpMonitorData = `{
   }
 }`
 
-const monitorPolicyData = `{
+const accountTypePolicyData = `{
+  "scope": "ACCOUNT_TYPE",
+  "subscope": "E2ET",
+  "name": "E2ET_%s",
+  "monitorId": "%s"
+}`
+
+const tenantPolicyData = `{
   "scope": "TENANT",
   "subscope": "%s",
   "name": "E2ET_%s",
-  "monitorId": "%s"
+  "monitorId": null
 }`

--- a/e2et/types.go
+++ b/e2et/types.go
@@ -276,21 +276,23 @@ type GetTasksResp struct {
 	First         bool `json:"first"`
 }
 
+type GetPolicyResp struct {
+	ID               string    `json:"id"`
+	Scope            string    `json:"scope"`
+	Subscope         string    `json:"subscope"`
+	CreatedTimestamp time.Time `json:"createdTimestamp"`
+	UpdatedTimestamp time.Time `json:"updatedTimestamp"`
+	Name             string    `json:"name"`
+	MonitorID        string    `json:"monitorId"`
+}
+
 type GetPoliciesResp struct {
-	Content []struct {
-		ID               string    `json:"id"`
-		Scope            string    `json:"scope"`
-		Subscope         string    `json:"subscope"`
-		CreatedTimestamp time.Time `json:"createdTimestamp"`
-		UpdatedTimestamp time.Time `json:"updatedTimestamp"`
-		Name             string    `json:"name"`
-		MonitorID        string    `json:"monitorId"`
-	} `json:"content"`
-	Number        int  `json:"number"`
-	TotalPages    int  `json:"totalPages"`
-	TotalElements int  `json:"totalElements"`
-	Last          bool `json:"last"`
-	First         bool `json:"first"`
+	Content       []GetPolicyResp `json:"content"`
+	Number        int             `json:"number"`
+	TotalPages    int             `json:"totalPages"`
+	TotalElements int             `json:"totalElements"`
+	Last          bool            `json:"last"`
+	First         bool            `json:"first"`
 }
 
 type CreatePolicyMonitorResp struct {


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-897

# What

update e2e test for latest policy monitor changes

# How
(The previous unworking policy code, created and deleted TENANT specific policies.)

Per James' suggestion, this was changed to use an ACCOUNT_TYPE policy with a special E2ET account type.  When cleaning up/deleting old policies, the new code firsts opts out of the policy with a TENANT specific policy.  This allows the cloned monitor to be unbound/deleted.

# How to test

run in dev enviroment


# TODO

The e2e account in each perf, staging and prod environments should be configured as an "E2ET" account type.
