### PR TITLE
Updated data-loader's cloudbuild's waitFor to be an array

### DIFF
--- a/data-loader/cloudbuild.yaml
+++ b/data-loader/cloudbuild.yaml
@@ -30,7 +30,8 @@ steps:
   # Set _CLOUDSDK_COMPUTE_REGION in the build trigger for non-dev clusters
   - name: 'gcr.io/$PROJECT_ID/helm'
     id: DEPLOY_APPLICATION
-    waitFor: HELM_CLONE
+    waitFor:
+    - HELM_CLONE
     args: ['upgrade', '--install', '${_SALUS_APP}', '--namespace', '${_APP_NAMESPACE}', '/workspace/helm-salus-${_SALUS_APP}']
     env:
     - 'CLOUDSDK_COMPUTE_ZONE=${_CLOUDSDK_COMPUTE_ZONE}'


### PR DESCRIPTION
IntelliJ was reporting

![image](https://user-images.githubusercontent.com/988985/87432027-11fc8f80-c5ad-11ea-87c3-7f96a7841153.png)

so hoping it fixes the vague build error:

```
Your build failed to run: failed unmarshalling build config data-loader/cloudbuild.yaml: json: cannot unmarshal string into Go value of type []json.RawMessage
```