### PR TITLE
Update get response struct

### DIFF
--- a/e2et/types.go
+++ b/e2et/types.go
@@ -252,7 +252,7 @@ type GetTasksResp struct {
 			CriticalStateDuration string        `json:"criticalStateDuration"`
 			WarningStateDuration  string        `json:"warningStateDuration"`
 			InfoStateDuration     string        `json:"infoStateDuration"`
-			CustomMetrics         interface{}   `json:"customMetrics"`
+			CustomMetrics         []interface{} `json:"customMetrics"`
 			WindowLength          interface{}   `json:"windowLength"`
 			WindowFields          interface{}   `json:"windowFields"`
 			FlappingDetection     bool          `json:"flappingDetection"`

--- a/e2et/types.go
+++ b/e2et/types.go
@@ -248,21 +248,15 @@ type GetTasksResp struct {
 		Name           string `json:"name"`
 		Measurement    string `json:"measurement"`
 		TaskParameters struct {
-			Info     interface{} `json:"info"`
-			Warning  interface{} `json:"warning"`
-			Critical struct {
-				Expression struct {
-					Field      string `json:"field"`
-					Threshold  int    `json:"threshold"`
-					Comparator string `json:"comparator"`
-				} `json:"expression"`
-				ConsecutiveCount int `json:"consecutiveCount"`
-			} `json:"critical"`
-			EvalExpressions   interface{} `json:"evalExpressions"`
-			WindowLength      interface{} `json:"windowLength"`
-			WindowFields      interface{} `json:"windowFields"`
-			FlappingDetection bool        `json:"flappingDetection"`
-			LabelSelector     struct {
+			StateExpressions      []interface{} `json:"stateExpressions"`
+			CriticalStateDuration string        `json:"criticalStateDuration"`
+			WarningStateDuration  string        `json:"warningStateDuration"`
+			InfoStateDuration     string        `json:"infoStateDuration"`
+			CustomMetrics         interface{}   `json:"customMetrics"`
+			WindowLength          interface{}   `json:"windowLength"`
+			WindowFields          interface{}   `json:"windowFields"`
+			FlappingDetection     bool          `json:"flappingDetection"`
+			LabelSelector         struct {
 				AgentEnvironment string `json:"agent_environment"`
 			} `json:"labelSelector"`
 		} `json:"taskParameters"`


### PR DESCRIPTION
I don't think this actually affects anything since the fields aren't accessed, but having the documented GetResponse match the new format seems like a good idea to help avoid confusion later on.