### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @GeorgeJahad @harageth @itzg @jjbuchan @rohitsngh27 @shabd67
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @GeorgeJahad @harageth @itzg @jjbuchan @rohitsngh27 @shabd67
-
+* @racker/salus-reviewers


### PR DESCRIPTION
Using this feature that automatically adds reviewers to new PRs - https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners