### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @racker/salus-reviewers
+* @GeorgeJahad @harageth @itzg @jjbuchan @rohitsngh27 @shabd67


### PR DESCRIPTION
Using the group would only list the group in a single item and then if one of those members approved the group it would remove the pending approval from everyone else.  That could work for some scenarios but not the general case where we want multiple people to look a PR.

![image](https://user-images.githubusercontent.com/4358210/95597641-21547300-0a0c-11eb-8a06-40461b478859.png)
