### PR TITLE
Bubbled up 4xx responses in data-loaders

### DIFF
--- a/data-loader/loaders.go
+++ b/data-loader/loaders.go
@@ -111,6 +111,7 @@ func NewLoader(log *zap.SugaredLogger, identityAuthenticator restclient.Intercep
 func (l *LoaderImpl) LoadAll(sourceContentPath string) (*LoaderStats, error) {
 
 	stats := &LoaderStats{}
+	var err1 error
 
 	for _, definition := range loaderDefinitions {
 		err := l.load(definition, sourceContentPath, stats)
@@ -118,13 +119,14 @@ func (l *LoaderImpl) LoadAll(sourceContentPath string) (*LoaderStats, error) {
 			l.log.Warnw("failed to process loader definition",
 				"err", err,
 				"definition", definition)
-			// but continue with other definitions
+			//but continue with other definitions
+			err1 = err
 		}
 	}
 
 	l.log.Infow("loaded content", "stats", stats)
 
-	return stats, nil
+	return stats, err1
 }
 
 func (l *LoaderImpl) load(definition LoaderDefinition, sourceContentPath string, stats *LoaderStats) error {


### PR DESCRIPTION
…ed to writeErrResponse method.

# Resolves

[SALUS-885](https://jira.rax.io/browse/SALUS-885)

# What

Bubbled up 4xx responses in data-loaders and sending error response back to Webhook

# How

Returned error from loaders.go/LoadAll so that it can be further passed to writeErrResponse method.

# How to test

https://github.com/racker/salus-tools/blob/itzg/salus-885-webhook-server-docs/data-loader/README.md
https://github.com/racker/salus-tools/pull/50#issuecomment-759580360

